### PR TITLE
Replace `@serializable` with `extends Serializable`

### DIFF
--- a/src/main/scala/pyspark_util/Pickling.scala
+++ b/src/main/scala/pyspark_util/Pickling.scala
@@ -36,8 +36,7 @@ import org.apache.spark.streaming.dstream.DStream
 
 import Conversions._
 
-@serializable
-class Pickling {
+class Pickling extends Serializable {
   register()
 
   def pickler() = {


### PR DESCRIPTION
Supports compiling with scala 2.11
